### PR TITLE
Bug/implement simple messaging protocol

### DIFF
--- a/ue4/connection.py
+++ b/ue4/connection.py
@@ -1,13 +1,16 @@
-"""
-UE4 connection module responsible for maintaining a TCP connection to
-the UE4 Editor's m2u-Plugin.
-Provides basic connect, disconnect and command-sending functionality.
+"""UE4 connection module.
+
+Responsible for maintaining a TCP connection to the UE4 Editor's
+m2u-Plugin.  Provides basic connect, disconnect and command-sending
+functionality.
 
 """
 
 import sys
 import logging
 import socket
+import struct
+import time
 
 _lg = logging.getLogger(__name__)
 
@@ -15,10 +18,18 @@ _lg = logging.getLogger(__name__)
 this = sys.modules[__name__]
 
 this._socket = None
-BUFFER_SIZE = 1024
+READ_BODY_TIMEOUT_S = 3.0
 
 
 def connect(*args):
+    """Connect to the specified address.
+
+    The first arg is used as the ip address, the second as the port
+    number. The first arg may also be a colon separated string of the
+    form 'address:port', the second arg will be ignored then. If None
+    is provided as the first arg, a default value will be used.
+
+    """
     use_default = True
     ip = '127.0.0.1'
     port = 3939
@@ -58,7 +69,10 @@ def send_message(message):
     if this._socket is None:
         _lg.error("Not connected.")
         return
-    this._socket.send(message)
+    content_length = len(message)
+    # Convert to Big Endian int32 and send as header.
+    this._socket.sendall(struct.pack('!I', content_length))
+    this._socket.sendall(message)
     return _receive_message()
 
 
@@ -66,8 +80,36 @@ def _receive_message():
     if this._socket is None:
         _lg.error("Not connected")
         return None
-    data = this._socket.recv(BUFFER_SIZE)
-    return data
+
+    # Get the content length header (4 bytes)
+    content_length = this._socket.recv(4)
+    if not content_length:
+        _lg.error("Could not retrieve message header.")
+        return None
+
+    # Convert from Big Endian int32.  Note: unpack returns a tuple.
+    content_length, = struct.unpack('!I', content_length)
+
+    time_read_body_start = time.time()
+    # Retrieve data from the stream until we read the proposed length
+    # of the message or we time out waiting for data.
+    message_buffer = b''
+    while content_length:
+        chunk = this._socket.recv(content_length)
+        if not chunk:
+            # If the content_length indicates a bigger message than
+            # has actually been sent, we might hang in this loop
+            # forever, unless we time out.
+            time_read_body_duration = time.time() - time_read_body_start
+            if time_read_body_duration > READ_BODY_TIMEOUT_S:
+                _lg.error("Failed to retrieve full message. "
+                          "Expected %i more bytes.", content_length)
+                return None
+        else:
+            message_buffer += chunk
+            content_length -= len(chunk)
+
+    return message_buffer
 
 
 def disconnect():

--- a/ue4/connection.py
+++ b/ue4/connection.py
@@ -19,6 +19,7 @@ this = sys.modules[__name__]
 
 this._socket = None
 READ_BODY_TIMEOUT_S = 3.0
+SOCKET_TIMEOUT_S = 30.0
 
 
 def connect(*args):
@@ -62,6 +63,7 @@ def _open_connection(tcp_ip='127.0.0.1', tcp_port=3939):
     disconnect()
 
     this._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    this._socket.settimeout(SOCKET_TIMEOUT_S)
     this._socket.connect((tcp_ip, tcp_port))
 
 

--- a/ue4/tests/test_messaging.py
+++ b/ue4/tests/test_messaging.py
@@ -1,0 +1,15 @@
+import pytest
+
+from m2u.ue4 import connection
+
+
+def test_send_message_size():
+    """Send a big message, larger than buffer size, so the server has to
+    read multiple chunks.
+
+    """
+    message = "TestMessageSize " + ("abcdefg" * 5000)
+    connection.connect()
+    result = connection.send_message(message)
+    assert result == str(len(message))
+    connection.disconnect()


### PR DESCRIPTION
Implement a simple content-length prefixed messaging protocol. This removes bugs arising from 'partially' received or sent messages that occur for bigger messages, small buffers or slow connections.

For why this is necessary, see: http://stupidpythonideas.blogspot.de/2013/05/sockets-are-byte-streams-not-message.html